### PR TITLE
TJW-242: pointing showdown feedback form

### DIFF
--- a/src/pointing-blackjack/PointingBlackjackSession.tsx
+++ b/src/pointing-blackjack/PointingBlackjackSession.tsx
@@ -7,6 +7,7 @@ import {
   usePointingBlackjack,
 } from "./PointingBlackjackProvider";
 import { isValidRoomCode } from "./roomCode";
+import { PointingShowdownFeedbackModal } from "./PointingShowdownFeedbackModal";
 import type { VoteValue } from "./types";
 
 type RoomPhase = "loading" | "unreachable" | "invalid" | "missing" | "exists";
@@ -141,6 +142,7 @@ export const PointingBlackjackSession: React.FC = () => {
 
   const [joinName, setJoinName] = useState("");
   const [copied, setCopied] = useState(false);
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
   const autoJoinTried = useRef(false);
   const [roomPhase, setRoomPhase] = useState<RoomPhase>("loading");
   /** Bumps the room probe when the user retries after a connection failure. */
@@ -404,10 +406,24 @@ export const PointingBlackjackSession: React.FC = () => {
           <p className="pb-muted">
             This session ends 60 minutes after it starts. Start a new one from the lobby anytime.
           </p>
-          <button type="button" className="pb-button pb-button--primary" onClick={onLeave}>
-            Back to lobby
-          </button>
+          <div className="pb-card-actions">
+            <button type="button" className="pb-button pb-button--primary" onClick={onLeave}>
+              Back to lobby
+            </button>
+            <button
+              type="button"
+              className="pb-button pb-button--ghost"
+              onClick={() => setFeedbackOpen(true)}
+            >
+              Feedback
+            </button>
+          </div>
         </div>
+        <PointingShowdownFeedbackModal
+          isOpen={feedbackOpen}
+          sessionId={state.sessionId}
+          onClose={() => setFeedbackOpen(false)}
+        />
       </div>
     );
   }
@@ -443,6 +459,13 @@ export const PointingBlackjackSession: React.FC = () => {
               onClick={() => setBrb(!myBrb)}
             >
               {myBrb ? "I'm back" : "BRB"}
+            </button>
+            <button
+              type="button"
+              className="pb-button pb-button--ghost"
+              onClick={() => setFeedbackOpen(true)}
+            >
+              Feedback
             </button>
             <button type="button" className="pb-button pb-button--ghost" onClick={onLeave}>
               Leave table
@@ -596,6 +619,11 @@ export const PointingBlackjackSession: React.FC = () => {
           </section>
         )}
       </>
+      <PointingShowdownFeedbackModal
+        isOpen={feedbackOpen}
+        sessionId={state.sessionId}
+        onClose={() => setFeedbackOpen(false)}
+      />
     </div>
   );
 };

--- a/src/pointing-blackjack/PointingShowdownFeedbackModal.tsx
+++ b/src/pointing-blackjack/PointingShowdownFeedbackModal.tsx
@@ -1,0 +1,138 @@
+import React, { useEffect, useRef, useState } from "react";
+
+type ModalPhase = "form" | "submitting" | "thanks" | "error";
+
+interface PointingShowdownFeedbackModalProps {
+  isOpen: boolean;
+  sessionId?: string;
+  onClose: () => void;
+}
+
+export const PointingShowdownFeedbackModal: React.FC<
+  PointingShowdownFeedbackModalProps
+> = ({ isOpen, sessionId, onClose }) => {
+  const [message, setMessage] = useState("");
+  const [phase, setPhase] = useState<ModalPhase>("form");
+  const [errorText, setErrorText] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setMessage("");
+    setPhase("form");
+    setErrorText("");
+    requestAnimationFrame(() => textareaRef.current?.focus());
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && phase !== "submitting") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isOpen, onClose, phase]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = message.trim();
+    if (trimmed.length < 4) return;
+
+    setPhase("submitting");
+    setErrorText("");
+
+    const fullMessage = sessionId
+      ? `[Room: ${sessionId}]\n\n${trimmed}`
+      : trimmed;
+
+    try {
+      const response = await fetch("/submit-feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: fullMessage,
+          customSubject: "Pointing Showdown Feedback",
+        }),
+      });
+
+      if (response.ok) {
+        setPhase("thanks");
+        window.setTimeout(onClose, 1500);
+      } else {
+        const text = await response.text();
+        setErrorText(text || "Something went wrong. Please try again.");
+        setPhase("error");
+      }
+    } catch {
+      setErrorText("Could not reach the server. Please try again.");
+      setPhase("error");
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="pb-feedback-modal__backdrop"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && phase !== "submitting") onClose();
+      }}
+    >
+      <div
+        className="pb-feedback-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="pb-feedback-title"
+      >
+        <button
+          type="button"
+          className="pb-feedback-modal__close"
+          onClick={onClose}
+          disabled={phase === "submitting"}
+          aria-label="Close"
+        >
+          ×
+        </button>
+
+        {phase === "thanks" ? (
+          <p className="pb-feedback-modal__thanks" role="status">
+            Thank you for your feedback
+          </p>
+        ) : (
+          <>
+            <h2 id="pb-feedback-title" className="pb-feedback-modal__title">
+              Feedback
+            </h2>
+            <form className="pb-form" onSubmit={handleSubmit}>
+              <label className="pb-label">
+                <textarea
+                  ref={textareaRef}
+                  className="pb-input pb-feedback-modal__textarea"
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  placeholder="Enter your anonymous feedback..."
+                  rows={5}
+                  disabled={phase === "submitting"}
+                  required
+                  minLength={4}
+                />
+              </label>
+              {phase === "error" && errorText ? (
+                <p className="pb-error" role="alert">
+                  {errorText}
+                </p>
+              ) : null}
+              <button
+                type="submit"
+                className="pb-button pb-button--primary"
+                disabled={message.trim().length < 4 || phase === "submitting"}
+              >
+                {phase === "submitting" ? "Sending…" : "Submit"}
+              </button>
+            </form>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/pointing-blackjack/pointing-blackjack.scss
+++ b/src/pointing-blackjack/pointing-blackjack.scss
@@ -701,3 +701,69 @@ $pb-glow-blue-lg: 0 0 18px rgba(74, 165, 255, 0.35);
     margin-bottom: 24px;
   }
 }
+
+.pb-feedback-modal {
+  position: relative;
+  width: min(480px, calc(100vw - 32px));
+  background: $pb-surface;
+  border: 1px solid $pb-border;
+  border-radius: 14px;
+  padding: 28px 24px 24px;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.55);
+
+  &__backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    background: rgba(0, 0, 0, 0.62);
+    backdrop-filter: blur(4px);
+  }
+
+  &__close {
+    position: absolute;
+    top: 12px;
+    right: 14px;
+    border: none;
+    background: transparent;
+    color: $pb-muted;
+    font-size: 28px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 8px;
+
+    &:hover:not(:disabled) {
+      color: $pb-text;
+      background: rgba(255, 255, 255, 0.06);
+    }
+
+    &:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+  }
+
+  &__title {
+    margin: 0 0 16px;
+    font-weight: 400;
+    font-size: 1.5rem;
+  }
+
+  &__textarea {
+    resize: vertical;
+    min-height: 120px;
+    font-family: inherit;
+    line-height: 1.45;
+  }
+
+  &__thanks {
+    margin: 24px 0;
+    text-align: center;
+    font-size: 1.25rem;
+    color: $pb-accent;
+  }
+}


### PR DESCRIPTION
## Summary
- Add an in-session feedback modal to Pointing Showdown with placeholder text, submit flow, loading state, and thank-you confirmation before close.
- Wire submissions to the existing `/submit-feedback` Cloudflare function (same Resend email path as the main site), tagged with `Pointing Showdown Feedback` subject and room ID in the message body.
- Expose a **Feedback** button in the session toolbar and on the game-over screen.

## Test plan
- [ ] Join a pointing showdown session and click **Feedback** in the toolbar
- [ ] Confirm modal shows placeholder "Enter your anonymous feedback..." and submit is disabled until 4+ characters
- [ ] Submit feedback and verify loading ("Sending…"), thank-you message, and auto-close after ~1.5s
- [ ] Confirm email arrives with subject "Pointing Showdown Feedback" and room code in body
- [ ] On game-over screen, open feedback modal and submit successfully
- [ ] Press Escape or click backdrop to dismiss (not while submitting)
