### PR TITLE
TJW-257: fix pointing showdown session freezes and missing rooms

### DIFF
--- a/server/pointing-blackjack.mjs
+++ b/server/pointing-blackjack.mjs
@@ -10,7 +10,7 @@ const PORT = Number(process.env.POINTING_BLACKJACK_PORT || 3333);
 const SESSION_TTL_MS = 60 * 60 * 1000;
 const HEARTBEAT_INTERVAL_MS = 25 * 1000;
 
-/** @typedef {{ name: string, online: true, brb?: boolean }} Player */
+/** @typedef {{ name: string, online: boolean, brb?: boolean }} Player */
 /** @typedef {{ id: string, revealed: boolean, gameOver: boolean, expiresAt: number, players: Map<string, Player>, votes: Map<string, number|null> }} Session */
 
 /** @type {Map<string, Session>} */
@@ -52,6 +52,7 @@ function closeAllSessionSockets(sessionId) {
 /**
  * Drop an empty session (no participants left).
  * @param {string} sessionId
+ * @deprecated Sessions now expire via TTL only; kept for expireSession cleanup.
  */
 function deleteEmptySession(sessionId) {
   clearSessionExpiryTimer(sessionId);
@@ -91,7 +92,7 @@ function buildStateForPlayer(session, viewerId) {
   const players = [...session.players.entries()].map(([id, pl]) => ({
     id,
     name: pl.name,
-    online: true,
+    online: pl.online !== false,
     brb: pl.brb === true,
   }));
 
@@ -119,6 +120,20 @@ function buildStateForPlayer(session, viewerId) {
   };
 }
 
+function sendJson(ws, payload) {
+  try {
+    if (ws.readyState === 1) {
+      ws.send(JSON.stringify(payload));
+    }
+  } catch {
+    // ignore stale socket
+  }
+}
+
+function sendError(ws, message) {
+  sendJson(ws, { type: "error", message });
+}
+
 function broadcastSession(sessionId) {
   const set = roomSockets.get(sessionId);
   const session = sessions.get(sessionId);
@@ -128,7 +143,7 @@ function broadcastSession(sessionId) {
     const meta = socketMeta.get(ws);
     if (!meta) continue;
     const state = buildStateForPlayer(session, meta.playerId);
-    ws.send(JSON.stringify({ type: "state", state }));
+    sendJson(ws, { type: "state", state });
   }
 }
 
@@ -162,6 +177,12 @@ function isValidSessionId(raw) {
  * @param {string} playerId
  */
 function registerPlayerSocket(ws, session, playerId) {
+  const prev = socketMeta.get(ws);
+  if (prev && prev.sessionId !== session.id) {
+    removeFromRoom(prev.sessionId, ws);
+  }
+  const pl = session.players.get(playerId);
+  if (pl) pl.online = true;
   socketMeta.set(ws, { sessionId: session.id, playerId });
   addToRoom(session.id, ws);
   broadcastSession(session.id);
@@ -187,12 +208,9 @@ function handleClose(ws) {
     }
   }
 
-  session.players.delete(playerId);
-  session.votes.delete(playerId);
-
-  if (session.players.size === 0) {
-    deleteEmptySession(sessionId);
-    return;
+  const pl = session.players.get(playerId);
+  if (pl) {
+    pl.online = false;
   }
 
   broadcastSession(sessionId);
@@ -320,7 +338,10 @@ wss.on("connection", (ws) => {
       let playerId = existingId;
       if (playerId && session.players.has(playerId)) {
         const pl = session.players.get(playerId);
-        if (pl) pl.name = name;
+        if (pl) {
+          pl.name = name;
+          pl.online = true;
+        }
       } else if (playerId) {
         session.players.set(playerId, { name, online: true });
       } else {
@@ -337,9 +358,22 @@ wss.on("connection", (ws) => {
       return;
     }
     const session = sessions.get(meta.sessionId);
-    if (!session || session.gameOver) return;
+    if (!session || session.gameOver) {
+      sendError(ws, "Session not found");
+      return;
+    }
     if (Date.now() > session.expiresAt) {
       expireSession(meta.sessionId);
+      sendError(ws, "Session not found");
+      return;
+    }
+
+    if (msg.type === "leave") {
+      session.players.delete(meta.playerId);
+      session.votes.delete(meta.playerId);
+      socketMeta.delete(ws);
+      removeFromRoom(meta.sessionId, ws);
+      broadcastSession(meta.sessionId);
       return;
     }
 
@@ -356,7 +390,10 @@ wss.on("connection", (ws) => {
       const v = msg.value;
       const allowed = [1, 2, 3, 5, 8, 13];
       if (!allowed.includes(v)) return;
-      if (!session.players.has(meta.playerId)) return;
+      if (!session.players.has(meta.playerId)) {
+        sendError(ws, "Not in a session");
+        return;
+      }
       session.votes.set(meta.playerId, v);
       broadcastSession(session.id);
       return;

--- a/src/pointing-blackjack/PointingBlackjackProvider.tsx
+++ b/src/pointing-blackjack/PointingBlackjackProvider.tsx
@@ -219,6 +219,9 @@ export const PointingBlackjackProvider: React.FC<{ children: React.ReactNode }> 
                 return;
               }
             }
+            if (msg.message === "Session not found") {
+              setState(null);
+            }
             setLastError(msg.message);
           }
         } catch {
@@ -465,6 +468,14 @@ export const PointingBlackjackProvider: React.FC<{ children: React.ReactNode }> 
   const leaveTable = useCallback(() => {
     clearReconnectTimer();
     closedByUserRef.current = true;
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      try {
+        ws.send(JSON.stringify({ type: "leave" }));
+      } catch {
+        // ignore
+      }
+    }
     wsRef.current?.close();
     wsRef.current = null;
     setState(null);

--- a/src/pointing-blackjack/PointingBlackjackSession.tsx
+++ b/src/pointing-blackjack/PointingBlackjackSession.tsx
@@ -422,6 +422,7 @@ export const PointingBlackjackSession: React.FC = () => {
         <PointingShowdownFeedbackModal
           isOpen={feedbackOpen}
           sessionId={state.sessionId}
+          playerName={state.players.find((p) => p.id === state.myPlayerId)?.name}
           onClose={() => setFeedbackOpen(false)}
         />
       </div>
@@ -448,6 +449,11 @@ export const PointingBlackjackSession: React.FC = () => {
           <div className="pb-session__room">
             <span className="pb-muted">Room:</span>
             <code className="pb-code">{state.sessionId}</code>
+            {connectionStatus !== "open" ? (
+              <span className="pb-session__connection" role="status">
+                {connectionStatus === "connecting" ? "Reconnecting…" : "Disconnected"}
+              </span>
+            ) : null}
           </div>
           <div className="pb-session__actions">
             <button type="button" className="pb-button" onClick={copyLink}>
@@ -622,6 +628,7 @@ export const PointingBlackjackSession: React.FC = () => {
       <PointingShowdownFeedbackModal
         isOpen={feedbackOpen}
         sessionId={state.sessionId}
+        playerName={myPlayer?.name}
         onClose={() => setFeedbackOpen(false)}
       />
     </div>

--- a/src/pointing-blackjack/PointingShowdownFeedbackModal.tsx
+++ b/src/pointing-blackjack/PointingShowdownFeedbackModal.tsx
@@ -5,12 +5,13 @@ type ModalPhase = "form" | "submitting" | "thanks" | "error";
 interface PointingShowdownFeedbackModalProps {
   isOpen: boolean;
   sessionId?: string;
+  playerName?: string;
   onClose: () => void;
 }
 
 export const PointingShowdownFeedbackModal: React.FC<
   PointingShowdownFeedbackModalProps
-> = ({ isOpen, sessionId, onClose }) => {
+> = ({ isOpen, sessionId, playerName, onClose }) => {
   const [message, setMessage] = useState("");
   const [phase, setPhase] = useState<ModalPhase>("form");
   const [errorText, setErrorText] = useState("");
@@ -41,9 +42,10 @@ export const PointingShowdownFeedbackModal: React.FC<
     setPhase("submitting");
     setErrorText("");
 
-    const fullMessage = sessionId
-      ? `[Room: ${sessionId}]\n\n${trimmed}`
-      : trimmed;
+    const meta: string[] = [];
+    if (sessionId) meta.push(`[Room: ${sessionId}]`);
+    if (playerName) meta.push(`[Player: ${playerName}]`);
+    const fullMessage = meta.length ? `${meta.join("\n")}\n\n${trimmed}` : trimmed;
 
     try {
       const response = await fetch("/submit-feedback", {

--- a/src/pointing-blackjack/pointing-blackjack.scss
+++ b/src/pointing-blackjack/pointing-blackjack.scss
@@ -246,6 +246,12 @@ $pb-glow-blue-lg: 0 0 18px rgba(74, 165, 255, 0.35);
     font-size: 17px;
   }
 
+  &__connection {
+    font-size: 14px;
+    color: #ffb86c;
+    font-style: italic;
+  }
+
   &__actions {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary

Fixes lingering Pointing Showdown reliability issues where large sessions (~10 users) would freeze, votes would stop registering, and refreshing would land on "No table here yet" as if the room had vanished.

**Server (`pointing-blackjack.mjs`)**
- Stop deleting sessions when the last socket disconnects — rooms now persist until the 60-minute TTL (or explicit game-over), so mass refresh / tunnel blips no longer wipe the table
- On disconnect, mark players offline instead of removing them and clearing their votes; votes and roster survive brief outages
- Add explicit `leave` message so "Leave table" still removes the player cleanly
- Return error responses instead of silently dropping votes/actions on dead sessions
- Harden `broadcastSession` with per-socket send error handling
- Fix room-switch edge case when reusing a socket across sessions

**Client**
- Clear stale React state on `"Session not found"` so the UI can't stay frozen on a dead session
- Send `leave` before closing the socket on intentional departures
- Show **Reconnecting…** / **Disconnected** in the session toolbar
- Include the player's room display name in feedback emails (`[Player: …]` alongside `[Room: …]`)

## Root cause

TJW-236 added heartbeat/reconnect plumbing, but the server still deleted the entire session whenever `players.size === 0` after a socket close. With ~10 users refreshing or a shared disconnect event, the room was gone before the 1s client reconnect could rejoin. The client kept showing stale `state`, so votes appeared to do nothing until refresh revealed the missing room.

## Test plan
- [ ] `npm test` and `npm run build` pass
- [ ] Start a room with 3+ tabs; refresh all tabs within ~1s — room should still exist and everyone reconnects
- [ ] Kill/restart the WS server mid-session — clients show disconnected state; after restart, rejoin works without stale frozen UI
- [ ] Click **Leave table** — player is removed from the roster (not left as offline ghost)
- [ ] Submit session feedback — email includes room ID and player display name
- [ ] **Deploy note:** production requires redeploying both the static app and the `pointing-blackjack` Node server (`wss://pointing-ws.tyler.cloud`)
