### PR TITLE
TJW-271: persist pointing showdown sessions in Supabase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@fortawesome/react-fontawesome": "^0.2.0",
+        "@supabase/supabase-js": "^2.108.2",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -3531,6 +3532,90 @@
       "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.108.2.tgz",
+      "integrity": "sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.108.2.tgz",
+      "integrity": "sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.4.tgz",
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.108.2.tgz",
+      "integrity": "sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.108.2.tgz",
+      "integrity": "sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.108.2.tgz",
+      "integrity": "sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.108.2.tgz",
+      "integrity": "sha512-hFhnPveb5JQg4a0QYicM0swT253YHMdfeRAl2BKHOlI5VAzuHxUGSr8RbwNLYNPauWOgQMS1H8sz8bvYlgwUfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.108.2",
+        "@supabase/functions-js": "2.108.2",
+        "@supabase/postgrest-js": "2.108.2",
+        "@supabase/realtime-js": "2.108.2",
+        "@supabase/storage-js": "2.108.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
@@ -9584,6 +9669,15 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -17364,9 +17458,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
+    "@supabase/supabase-js": "^2.108.2",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/server/pointing-blackjack-store.mjs
+++ b/server/pointing-blackjack-store.mjs
@@ -2,6 +2,7 @@
  * Supabase persistence for Pointing Showdown sessions.
  * Requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.
  */
+import WebSocket from "ws";
 import { createClient } from "@supabase/supabase-js";
 
 /**
@@ -25,6 +26,7 @@ export function loadSupabaseConfig() {
 export function createPointingStore(cfg) {
   const supabase = createClient(cfg.url, cfg.serviceRoleKey, {
     auth: { persistSession: false, autoRefreshToken: false },
+    realtime: { transport: WebSocket },
   });
 
   /**

--- a/server/pointing-blackjack-store.mjs
+++ b/server/pointing-blackjack-store.mjs
@@ -1,0 +1,142 @@
+/**
+ * Supabase persistence for Pointing Showdown sessions.
+ * Requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.
+ */
+import { createClient } from "@supabase/supabase-js";
+
+/**
+ * @typedef {{ name: string, online: boolean, brb?: boolean }} Player
+ * @typedef {{ id: string, revealed: boolean, gameOver: boolean, expiresAt: number, players: Map<string, Player>, votes: Map<string, number|null> }} Session
+ */
+
+/**
+ * @returns {{ url: string, serviceRoleKey: string } | null}
+ */
+export function loadSupabaseConfig() {
+  const url = (process.env.SUPABASE_URL || "").trim();
+  const serviceRoleKey = (process.env.SUPABASE_SERVICE_ROLE_KEY || "").trim();
+  if (!url || !serviceRoleKey) return null;
+  return { url, serviceRoleKey };
+}
+
+/**
+ * @param {{ url: string, serviceRoleKey: string }} cfg
+ */
+export function createPointingStore(cfg) {
+  const supabase = createClient(cfg.url, cfg.serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  /**
+   * @param {Session} session
+   */
+  async function persistSession(session) {
+    const { error: sessionErr } = await supabase.from("pointing_sessions").upsert({
+      id: session.id,
+      revealed: session.revealed,
+      game_over: session.gameOver,
+      expires_at: new Date(session.expiresAt).toISOString(),
+    });
+    if (sessionErr) throw sessionErr;
+
+    const { error: deleteVotesErr } = await supabase
+      .from("pointing_votes")
+      .delete()
+      .eq("session_id", session.id);
+    if (deleteVotesErr) throw deleteVotesErr;
+
+    const { error: deletePlayersErr } = await supabase
+      .from("pointing_players")
+      .delete()
+      .eq("session_id", session.id);
+    if (deletePlayersErr) throw deletePlayersErr;
+
+    const playerRows = [...session.players.entries()].map(([id, pl]) => ({
+      id,
+      session_id: session.id,
+      name: pl.name,
+      brb: pl.brb === true,
+    }));
+    if (playerRows.length) {
+      const { error: playersErr } = await supabase.from("pointing_players").insert(playerRows);
+      if (playersErr) throw playersErr;
+    }
+
+    const voteRows = [...session.votes.entries()]
+      .filter(([, value]) => value !== null && value !== undefined)
+      .map(([playerId, value]) => ({
+        session_id: session.id,
+        player_id: playerId,
+        value,
+      }));
+    if (voteRows.length) {
+      const { error: votesErr } = await supabase.from("pointing_votes").insert(voteRows);
+      if (votesErr) throw votesErr;
+    }
+  }
+
+  /**
+   * @param {string} sessionId
+   */
+  async function deleteSession(sessionId) {
+    const { error } = await supabase.from("pointing_sessions").delete().eq("id", sessionId);
+    if (error) throw error;
+  }
+
+  async function deleteExpiredSessions() {
+    const now = new Date().toISOString();
+    const { error } = await supabase.from("pointing_sessions").delete().lt("expires_at", now);
+    if (error) throw error;
+  }
+
+  /**
+   * Load live sessions from Supabase into the in-memory map.
+   * @param {Map<string, Session>} sessions
+   */
+  async function hydrateSessions(sessions) {
+    const now = new Date().toISOString();
+    const { data: sessionRows, error: sessionErr } = await supabase
+      .from("pointing_sessions")
+      .select("id, revealed, game_over, expires_at")
+      .gt("expires_at", now)
+      .eq("game_over", false);
+    if (sessionErr) throw sessionErr;
+
+    for (const row of sessionRows ?? []) {
+      const { data: playerRows, error: playersErr } = await supabase
+        .from("pointing_players")
+        .select("id, name, brb")
+        .eq("session_id", row.id);
+      if (playersErr) throw playersErr;
+
+      const { data: voteRows, error: votesErr } = await supabase
+        .from("pointing_votes")
+        .select("player_id, value")
+        .eq("session_id", row.id);
+      if (votesErr) throw votesErr;
+
+      /** @type {Session} */
+      const session = {
+        id: row.id,
+        revealed: row.revealed === true,
+        gameOver: row.game_over === true,
+        expiresAt: new Date(row.expires_at).getTime(),
+        players: new Map(
+          (playerRows ?? []).map((p) => [
+            p.id,
+            { name: p.name, online: false, brb: p.brb === true },
+          ])
+        ),
+        votes: new Map((voteRows ?? []).map((v) => [v.player_id, v.value])),
+      };
+      sessions.set(row.id, session);
+    }
+  }
+
+  return {
+    persistSession,
+    deleteSession,
+    deleteExpiredSessions,
+    hydrateSessions,
+  };
+}

--- a/server/pointing-blackjack.mjs
+++ b/server/pointing-blackjack.mjs
@@ -2,13 +2,20 @@
  * Real-time session server for Pointing Blackjack.
  * Run: node server/pointing-blackjack.mjs
  * Port: POINTING_BLACKJACK_PORT or 3333
+ *
+ * Session state is persisted in Supabase (SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY).
  */
 import { WebSocketServer } from "ws";
 import { randomUUID } from "crypto";
+import {
+  createPointingStore,
+  loadSupabaseConfig,
+} from "./pointing-blackjack-store.mjs";
 
 const PORT = Number(process.env.POINTING_BLACKJACK_PORT || 3333);
-const SESSION_TTL_MS = 60 * 60 * 1000;
+const SESSION_TTL_MS = 2 * 60 * 60 * 1000;
 const HEARTBEAT_INTERVAL_MS = 25 * 1000;
+const EXPIRED_SESSION_CLEANUP_MS = 10 * 60 * 1000;
 
 /** @typedef {{ name: string, online: boolean, brb?: boolean }} Player */
 /** @typedef {{ id: string, revealed: boolean, gameOver: boolean, expiresAt: number, players: Map<string, Player>, votes: Map<string, number|null> }} Session */
@@ -21,6 +28,33 @@ const socketMeta = new Map();
 const roomSockets = new Map();
 /** @type {Map<string, ReturnType<typeof setTimeout>>} */
 const sessionExpiryTimers = new Map();
+
+/** @type {ReturnType<typeof createPointingStore> | null} */
+let store = null;
+
+/**
+ * @param {Session} session
+ */
+async function saveSession(session) {
+  if (!store) return;
+  try {
+    await store.persistSession(session);
+  } catch (err) {
+    console.error(`Failed to persist session ${session.id}:`, err);
+  }
+}
+
+/**
+ * @param {string} sessionId
+ */
+async function removeSessionFromStore(sessionId) {
+  if (!store) return;
+  try {
+    await store.deleteSession(sessionId);
+  } catch (err) {
+    console.error(`Failed to delete session ${sessionId}:`, err);
+  }
+}
 
 function clearSessionExpiryTimer(sessionId) {
   const t = sessionExpiryTimers.get(sessionId);
@@ -72,6 +106,7 @@ function expireSession(sessionId) {
   broadcastSession(sessionId);
   closeAllSessionSockets(sessionId);
   sessions.delete(sessionId);
+  void removeSessionFromStore(sessionId);
 }
 
 function scheduleSessionExpiry(sessionId) {
@@ -216,20 +251,22 @@ function handleClose(ws) {
   broadcastSession(sessionId);
 }
 
-const wss = new WebSocketServer({ port: PORT, host: "0.0.0.0" });
-
 function markSocketAlive(ws) {
   ws.isAlive = true;
 }
 
-wss.on("connection", (ws) => {
-  markSocketAlive(ws);
-  ws.on("pong", () => markSocketAlive(ws));
-});
+/**
+ * @param {import('ws').WebSocketServer} wss
+ */
+function attachSocketHandlers(wss) {
+  wss.on("connection", (ws) => {
+    markSocketAlive(ws);
+    ws.on("pong", () => markSocketAlive(ws));
+  });
 
-wss.on("connection", (ws) => {
-  ws.on("close", () => handleClose(ws));
-  ws.on("message", (raw) => {
+  wss.on("connection", (ws) => {
+    ws.on("close", () => handleClose(ws));
+    ws.on("message", (raw) => {
     let msg;
     try {
       msg = JSON.parse(raw.toString());
@@ -314,6 +351,7 @@ wss.on("connection", (ws) => {
       sessions.set(sessionId, session);
       scheduleSessionExpiry(sessionId);
       registerPlayerSocket(ws, session, creatorId);
+      void saveSession(session);
       return;
     }
 
@@ -349,6 +387,7 @@ wss.on("connection", (ws) => {
         session.players.set(playerId, { name, online: true });
       }
       registerPlayerSocket(ws, session, playerId);
+      void saveSession(session);
       return;
     }
 
@@ -374,6 +413,7 @@ wss.on("connection", (ws) => {
       socketMeta.delete(ws);
       removeFromRoom(meta.sessionId, ws);
       broadcastSession(meta.sessionId);
+      void saveSession(session);
       return;
     }
 
@@ -382,6 +422,7 @@ wss.on("connection", (ws) => {
       if (pl) {
         pl.brb = msg.brb === true;
         broadcastSession(session.id);
+        void saveSession(session);
       }
       return;
     }
@@ -396,18 +437,21 @@ wss.on("connection", (ws) => {
       }
       session.votes.set(meta.playerId, v);
       broadcastSession(session.id);
+      void saveSession(session);
       return;
     }
 
     if (msg.type === "clearVote") {
       session.votes.delete(meta.playerId);
       broadcastSession(session.id);
+      void saveSession(session);
       return;
     }
 
     if (msg.type === "reveal") {
       session.revealed = true;
       broadcastSession(session.id);
+      void saveSession(session);
       return;
     }
 
@@ -415,36 +459,80 @@ wss.on("connection", (ws) => {
       session.revealed = false;
       session.votes.clear();
       broadcastSession(session.id);
+      void saveSession(session);
       return;
     }
+    });
   });
-});
+}
 
-const heartbeatTimer = setInterval(() => {
-  for (const ws of wss.clients) {
-    if (ws.isAlive === false) {
-      try {
-        ws.terminate();
-      } catch {
-        // ignore
-      }
-      continue;
-    }
-    ws.isAlive = false;
-    try {
-      ws.ping();
-    } catch {
-      try {
-        ws.terminate();
-      } catch {
-        // ignore
-      }
-    }
+async function main() {
+  const supabaseCfg = loadSupabaseConfig();
+  if (!supabaseCfg) {
+    console.error(
+      "Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY — Pointing Showdown requires Supabase."
+    );
+    process.exit(1);
   }
-}, HEARTBEAT_INTERVAL_MS);
+  store = createPointingStore(supabaseCfg);
+  try {
+    await store.hydrateSessions(sessions);
+    for (const sessionId of sessions.keys()) {
+      scheduleSessionExpiry(sessionId);
+    }
+    console.log(`Hydrated ${sessions.size} session(s) from Supabase`);
+  } catch (err) {
+    console.error("Failed to hydrate sessions from Supabase:", err);
+    process.exit(1);
+  }
 
-wss.on("close", () => {
-  clearInterval(heartbeatTimer);
+  const wss = new WebSocketServer({ port: PORT, host: "0.0.0.0" });
+  attachSocketHandlers(wss);
+
+  const heartbeatTimer = setInterval(() => {
+    for (const ws of wss.clients) {
+      if (ws.isAlive === false) {
+        try {
+          ws.terminate();
+        } catch {
+          // ignore
+        }
+        continue;
+      }
+      ws.isAlive = false;
+      try {
+        ws.ping();
+      } catch {
+        try {
+          ws.terminate();
+        } catch {
+          // ignore
+        }
+      }
+    }
+  }, HEARTBEAT_INTERVAL_MS);
+
+  const cleanupTimer = setInterval(() => {
+    const now = Date.now();
+    for (const [sessionId, session] of sessions) {
+      if (!sessionIsLive(session) || now > session.expiresAt) {
+        expireSession(sessionId);
+      }
+    }
+    void store.deleteExpiredSessions().catch((err) => {
+      console.error("Failed to delete expired Supabase sessions:", err);
+    });
+  }, EXPIRED_SESSION_CLEANUP_MS);
+
+  wss.on("close", () => {
+    clearInterval(heartbeatTimer);
+    clearInterval(cleanupTimer);
+  });
+
+  console.log(`Pointing Blackjack server on ws://localhost:${PORT}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
 });
-
-console.log(`Pointing Blackjack server on ws://localhost:${PORT}`);

--- a/server/pointing-blackjack.service.example
+++ b/server/pointing-blackjack.service.example
@@ -19,6 +19,9 @@ Restart=on-failure
 RestartSec=5
 Environment=NODE_ENV=production
 Environment=POINTING_BLACKJACK_PORT=3333
+# Supabase (run supabase/migrations/20260629000000_pointing_showdown.sql first)
+Environment=SUPABASE_URL=https://YOUR_PROJECT.supabase.co
+Environment=SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 [Install]
 WantedBy=multi-user.target

--- a/src/pointing-blackjack/types.ts
+++ b/src/pointing-blackjack/types.ts
@@ -15,7 +15,7 @@ export type SessionState = {
   myPlayerId: string;
   revealed: boolean;
   gameOver: boolean;
-  /** Unix ms when the server drops this table (60 minutes after creation). */
+  /** Unix ms when the server drops this table (2 hours after creation). */
   expiresAt: number;
   players: PlayerRow[];
   voteByPlayer: Record<string, SerializedVote>;

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,414 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "tyler.cloud"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+# Controls whether new tables, views, sequences and functions created in the `public` schema by
+# `postgres` are reachable through the Data API roles (`anon`, `authenticated`, `service_role`)
+# without explicit GRANTs. When unset, new entities are NOT auto-exposed, matching the new cloud
+# default. Set to `true` to keep the legacy behaviour of auto-exposing new entities; this is
+# deprecated and the field is removed on 2026-10-30 once the always-revoked behaviour is permanent.
+# auto_expose_new_tables = true
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[local_smtp]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+[storage.vector]
+enabled = true
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ `{{ .Code }}` }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ `{{ .Code }}` }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# pg-delta is the schema diff engine for db diff / db pull / db remote commit.
+# Set enabled = false to fall back to the legacy migra engine.
+[experimental.pgdelta]
+enabled = true
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260629000000_pointing_showdown.sql
+++ b/supabase/migrations/20260629000000_pointing_showdown.sql
@@ -35,3 +35,6 @@ alter table public.pointing_players enable row level security;
 alter table public.pointing_votes enable row level security;
 
 -- No anon/authenticated policies: only the service role (WebSocket server) accesses these tables.
+grant all on public.pointing_sessions to service_role;
+grant all on public.pointing_players to service_role;
+grant all on public.pointing_votes to service_role;

--- a/supabase/migrations/20260629000000_pointing_showdown.sql
+++ b/supabase/migrations/20260629000000_pointing_showdown.sql
@@ -1,0 +1,37 @@
+-- Pointing Showdown session persistence (TJW-271).
+-- Run in the Supabase SQL editor or via `supabase db push`.
+
+create table if not exists public.pointing_sessions (
+  id text primary key,
+  revealed boolean not null default false,
+  game_over boolean not null default false,
+  expires_at timestamptz not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists pointing_sessions_expires_at_idx
+  on public.pointing_sessions (expires_at);
+
+create table if not exists public.pointing_players (
+  id uuid primary key,
+  session_id text not null references public.pointing_sessions (id) on delete cascade,
+  name text not null,
+  brb boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists pointing_players_session_id_idx
+  on public.pointing_players (session_id);
+
+create table if not exists public.pointing_votes (
+  session_id text not null references public.pointing_sessions (id) on delete cascade,
+  player_id uuid not null references public.pointing_players (id) on delete cascade,
+  value integer not null,
+  primary key (session_id, player_id)
+);
+
+alter table public.pointing_sessions enable row level security;
+alter table public.pointing_players enable row level security;
+alter table public.pointing_votes enable row level security;
+
+-- No anon/authenticated policies: only the service role (WebSocket server) accesses these tables.


### PR DESCRIPTION
## Summary
- Persist pointing showdown session state (players, votes, reveal/round status) in Supabase so tables survive WebSocket server restarts.
- Extend session TTL from 1 hour to 2 hours and delete expired rows from Supabase on a 10-minute cleanup interval.
- Add SQL migration (`supabase/migrations/20260629000000_pointing_showdown.sql`) and document required `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` env vars.

## Test plan
- [ ] Run the migration in Supabase SQL editor
- [ ] Set `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`, then `npm run server:blackjack`
- [ ] Create a room, vote, restart the server — players and votes should still be present
- [ ] Confirm sessions are removed after 2 hours (or by manually setting `expires_at` in the DB)