### PR TITLE
Redirect /pointing-showdown to pointy.website

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,4 @@
+# Pointing Showdown moved to its own site.
+/pointing-showdown    https://pointy.website/           301
+/pointing-showdown/   https://pointy.website/           301
+/pointing-showdown/*  https://pointy.website/:splat     301

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,31 @@
-import React from "react";
-import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+import React, { useEffect } from "react";
+import { BrowserRouter, Navigate, Route, Routes, useParams } from "react-router-dom";
 import HomePage from "./HomePage";
-import { PointingBlackjackLayout } from "./pointing-blackjack/PointingBlackjackLayout";
-import { PointingBlackjackLobby } from "./pointing-blackjack/PointingBlackjackLobby";
-import { PointingBlackjackSession } from "./pointing-blackjack/PointingBlackjackSession";
+
+/** Edge `_redirects` handles production; this covers local/dev and client navigations. */
+const RedirectPointingShowdown: React.FC = () => {
+  const { sessionId } = useParams<{ sessionId?: string }>();
+  useEffect(() => {
+    const dest = sessionId
+      ? `https://pointy.website/${sessionId}`
+      : "https://pointy.website/";
+    window.location.replace(dest);
+  }, [sessionId]);
+  return (
+    <p style={{ padding: "2rem", fontFamily: "system-ui, sans-serif" }}>
+      Pointing Showdown has moved to{" "}
+      <a href="https://pointy.website/">pointy.website</a>…
+    </p>
+  );
+};
 
 const App: React.FC = () => {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<HomePage />} />
-        <Route path="/pointing-showdown" element={<PointingBlackjackLayout />}>
-          <Route index element={<PointingBlackjackLobby />} />
-          <Route path=":sessionId" element={<PointingBlackjackSession />} />
-        </Route>
+        <Route path="/pointing-showdown" element={<RedirectPointingShowdown />} />
+        <Route path="/pointing-showdown/:sessionId" element={<RedirectPointingShowdown />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>


### PR DESCRIPTION
## Summary
- Add Cloudflare Pages `_redirects` so `/pointing-showdown` and `/pointing-showdown/:room` 301 to `https://pointy.website/` (and `/:room`).
- Replace in-app pointing routes with a client-side redirect fallback for local/dev.

## Test plan
- [ ] After deploy: `curl -sI https://tyler.cloud/pointing-showdown` → 301 to `https://pointy.website/`
- [ ] `curl -sI https://tyler.cloud/pointing-showdown/abc123` → 301 to `https://pointy.website/abc123`
- [ ] Browser visit to old lobby/room URLs lands on pointy.website
