### PR TITLE
Restore homepage text over constellation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,14 +5,13 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/img/favicon.ico" />
     <link rel="preload" href="img/face.jpg" as="image" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta
       name="apple-mobile-web-app-status-bar-style"
       content="black-translucent"
     />
-    <meta name="theme-color" content="#12161f" />
-    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#222222" />
     <meta
       name="description"
       content="Tyler Woodfin is an experienced React Native engineer and team lead in San Francisco."

--- a/src/ConstellationBackground.tsx
+++ b/src/ConstellationBackground.tsx
@@ -3,6 +3,9 @@ import Particles, { initParticlesEngine } from "@tsparticles/react";
 import { loadSlim } from "@tsparticles/slim";
 import type { Engine, ISourceOptions } from "@tsparticles/engine";
 
+const BG_GRADIENT =
+  "linear-gradient(145deg, #1a1c24 0%, #12161f 48%, #0b1522 100%)";
+
 /** Interactive constellation particle background for the homepage. */
 const ConstellationBackground: React.FC = () => {
   const [init, setInit] = useState(false);
@@ -37,18 +40,15 @@ const ConstellationBackground: React.FC = () => {
 
   const particlesOptions = useMemo(
     (): ISourceOptions => ({
-      // Sized via CSS (.constellation-layer) for reliable iOS Safari coverage.
       fullScreen: {
-        enable: false,
+        enable: true,
+        zIndex: -1,
       },
       background: {
-        color: {
-          value: "transparent",
-        },
+        image: BG_GRADIENT,
       },
       fpsLimit: 120,
       interactivity: {
-        detectsOn: "window",
         events: {
           onHover: {
             enable: true,
@@ -106,17 +106,15 @@ const ConstellationBackground: React.FC = () => {
     []
   );
 
-  if (reduceMotion || !init) {
-    return <div className="constellation-layer" aria-hidden="true" />;
+  if (reduceMotion) {
+    return <div className="constellation-fallback" aria-hidden="true" />;
   }
 
-  return (
-    <Particles
-      id="tyler-cloud-constellation"
-      className="constellation-layer"
-      options={particlesOptions}
-    />
-  );
+  if (!init) {
+    return <div className="constellation-fallback" aria-hidden="true" />;
+  }
+
+  return <Particles id="tyler-cloud-constellation" options={particlesOptions} />;
 };
 
 export default ConstellationBackground;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -14,44 +14,22 @@ $border-radius-base: 12px;
 $box-shadow-base: -14px 21px 28px -2px rgba(135, 135, 135, 0.34);
 $media-breakpoint: 768px;
 $transition: max-height 500ms ease-in-out, opacity 500ms ease-in-out;
-$bg-gradient: linear-gradient(145deg, #1a1c24 0%, #12161f 48%, #0b1522 100%);
-
-html {
-  background: $bg-gradient;
-  background-color: #12161f;
-  min-height: 100%;
-}
 
 body {
   font-family: $font-primary;
   color: $color-primary;
   font-size: $font-size-base;
-  background: $bg-gradient;
-  background-color: #12161f;
-  margin: 0;
-  min-height: 100%;
-  // Keep the painted background edge-to-edge; safe-area lives on content.
-  padding: 0;
+  background-color: $color-background;
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
-// Fixed layer behind page content. Avoid z-index: -1 — on iOS Safari that
-// can slip behind <body> and expose the browser's default black canvas.
-.constellation-layer {
+.constellation-fallback {
   position: fixed;
   inset: 0;
-  width: 100%;
-  height: 100%;
-  height: 100dvh;
-  z-index: 0;
+  z-index: -1;
+  background: linear-gradient(145deg, #1a1c24 0%, #12161f 48%, #0b1522 100%);
   pointer-events: none;
-  background: $bg-gradient;
-  overflow: hidden;
-
-  canvas {
-    display: block;
-    width: 100% !important;
-    height: 100% !important;
-  }
 }
 
 .app {
@@ -59,16 +37,11 @@ body {
   z-index: 1;
   width: 100%;
   min-height: 100vh;
-  min-height: 100dvh;
 
   &__content {
     width: 50%;
     max-width: 600px;
     margin: auto;
-    padding-top: env(safe-area-inset-top);
-    padding-bottom: env(safe-area-inset-bottom);
-    padding-left: env(safe-area-inset-left);
-    padding-right: env(safe-area-inset-right);
 
     @media (max-width: $media-breakpoint) {
       width: 80%;


### PR DESCRIPTION
## Summary
- Revert PR #45's iOS Safari black-bar experiment
- That change put the particle layer above the page content, so tyler.cloud showed wallpaper only
- Restores the PR #44 constellation behavior (matches local): text/links visible again; iOS top/bottom chrome bars may remain

## Test plan
- [ ] tyler.cloud shows "Hi, I'm Tyler Woodfin." and nav links
- [ ] Constellation still renders behind content
- [ ] Links remain clickable